### PR TITLE
Exclude test project from NuGet

### DIFF
--- a/src/ImportPluginBase.Tests/ImportPluginBase.Tests.csproj
+++ b/src/ImportPluginBase.Tests/ImportPluginBase.Tests.csproj
@@ -1,11 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <OutputType>Library</OutputType>
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <AssemblyName>ImportPluginBase.Tests</AssemblyName>
-        <RootNamespace>ImportPluginBase</RootNamespace>
+        <AssemblyName>Zeiss.PiWeb.ImportPluginBase.Tests</AssemblyName>
+        <RootNamespace>Zeiss.PiWeb.ImportPluginBase.Tests</RootNamespace>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
With `<IsPackable>false</IsPackable>` the test project will not be part of the NuGet.