### PR TITLE
fix: License short ID

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-BSD 3-Clause License
+BSD-3-Clause
 
 Copyright (c) 2023, Carl Zeiss Industrielle Messtechnik GmbH
 


### PR DESCRIPTION
For automatic recognition of licenses using the short SPDX identifier is best practice. This PR fixes it in the license file.